### PR TITLE
fix(frontend): explain why Add player button is disabled after game start

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@killer-game/frontend",
-  "version": "4.8.1",
+  "version": "4.8.2",
   "private": true,
   "engines": {
     "node": ">=24.0.0 <25.0.0"

--- a/frontend/src/components/pages/GameDashboardInviteButton.jsx
+++ b/frontend/src/components/pages/GameDashboardInviteButton.jsx
@@ -30,9 +30,15 @@ export default function GameDashboardInviteButton({
         className="btn btn-secondary"
         onClick={() => setNewPlayerModalOpen(true)}
         disabled={disabled}
+        title={disabled ? t("GameDashboardInvite.gameStarted") : undefined}
       >
         ➕ {t("GameDashboardInvite.addPlayerButton")}
       </button>
+      {disabled && (
+        <p className="text-warning text-sm mt-1">
+          {t("GameDashboardInvite.gameStarted")}
+        </p>
+      )}
       <Modal
         isOpen={newPlayerModalOpen}
         title={t("GameDashboardInvite.modalTitle")}


### PR DESCRIPTION
Closes #38

## Problem
After starting a game, the "Add a player" button on the admin dashboard becomes disabled with no tooltip, hover text, or explanation. Users who start a game and want to add someone are left confused with no feedback (while the join URL correctly shows a warning).

## Solution
Add a  tooltip on the disabled button and a visible warning text below it, reusing the existing `GameDashboardInvite.gameStarted` translation keys (already present in `en.json` and `fr.json` and already used by `GameJoinLink`).

## Changes
- `frontend/src/components/pages/GameDashboardInviteButton.jsx`: show tooltip + warning text when `disabled`
- `frontend/package.json`: bump to 4.8.2

## Verification
`cd frontend && npm test` -> 28 tests passed (13 files).