### PR TITLE
fix(i18n): translate raw keys on /games, join page, and start modal

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -250,7 +250,9 @@
   "game-join": {
     "title": "Join the game",
     "GameJoinContent": {
-      "thereIsAlreadyXPlayers": "There is already {count} player in the game."
+      "thereIsAlreadyXPlayers_zero": "There are no players in the game yet.",
+      "thereIsAlreadyXPlayers_one": "There is already {count} player in the game.",
+      "thereIsAlreadyXPlayers_other": "There are already {count} players in the game."
     }
   },
   "games-created": {

--- a/frontend/locales/fr.json
+++ b/frontend/locales/fr.json
@@ -251,6 +251,7 @@
   "game-join": {
     "title": "Rejoindre la partie",
     "GameJoinContent": {
+      "thereIsAlreadyXPlayers_zero": "Il n'y a pas encore de joueur dans la partie.",
       "thereIsAlreadyXPlayers_one": "Il y a déjà {count} joueur dans la partie.",
       "thereIsAlreadyXPlayers_other": "Il y a déjà {count} joueurs dans la partie."
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@killer-game/frontend",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "private": true,
   "engines": {
     "node": ">=24.0.0 <25.0.0"

--- a/frontend/src/__tests__/i18n.test.js
+++ b/frontend/src/__tests__/i18n.test.js
@@ -27,4 +27,22 @@ describe('i18n Configuration', () => {
     const t = await getTranslations('common');
     expect(t('appName')).toBe('appName');
   });
+
+  it('should have plural variants for game-join.GameJoinContent.thereIsAlreadyXPlayers in both locales', async () => {
+    const en = (await import('../../locales/en.json')).default['game-join'].GameJoinContent;
+    const fr = (await import('../../locales/fr.json')).default['game-join'].GameJoinContent;
+    for (const form of ['_zero', '_one', '_other']) {
+      expect(en).toHaveProperty('thereIsAlreadyXPlayers' + form);
+      expect(fr).toHaveProperty('thereIsAlreadyXPlayers' + form);
+    }
+  });
+
+  it('should have a games-created namespace (not game-created) in both locales', async () => {
+    const en = (await import('../../locales/en.json')).default;
+    const fr = (await import('../../locales/fr.json')).default;
+    expect(en).toHaveProperty('games-created');
+    expect(fr).toHaveProperty('games-created');
+    expect(en).not.toHaveProperty('game-created');
+    expect(fr).not.toHaveProperty('game-created');
+  });
 });

--- a/frontend/src/app/[locale]/games/page.jsx
+++ b/frontend/src/app/[locale]/games/page.jsx
@@ -18,7 +18,7 @@ export default function GamesPages() {
  * @returns {Promise<import("next").Metadata>}
  */
 export async function generateMetadata() {
-  const t = await getTranslations("game-created");
+  const t = await getTranslations("games-created");
 
   return {
     title: t("title"),

--- a/frontend/src/components/organisms/GameStartButton.jsx
+++ b/frontend/src/components/organisms/GameStartButton.jsx
@@ -65,7 +65,7 @@ export default function GameStartButton({ game, players, onChange, disabled }) {
       <Modal
         isOpen={isOpen}
         onClosed={() => setIsOpen(false)}
-        title={"You are about to start the game"}
+        title={t("GameStartButton.areYouSure")}
         content={
           isOpen && (
             <>


### PR DESCRIPTION
Fixes #34

## Changes

- **Page title on `/fr/games`**: the `generateMetadata` helper used the non-existent namespace `game-created` (singular). Switched to `games-created` (plural) so the title resolves to the translated string instead of the raw key `game-created.title`.
- **Join page player count**: `game-join.GameJoinContent.thereIsAlreadyXPlayers` was missing the `_zero` ICU plural form in `fr.json` and had no plural variants at all in `en.json`. next-intl could not resolve the message for certain `count` values and fell back to the raw key. Added `_zero`/`_one`/`_other` variants in both locales.
- **Confirmation modal title**: the start-game modal in `GameStartButton` hardcoded `"You are about to start the game"` in English. Replaced it with the existing translated key `GameStartButton.areYouSure`.

## Tests

- Added i18n tests asserting the plural variants exist in both locales and that the `games-created` namespace is present (and the singular `game-created` is not).
- Full frontend suite passes: `47 passed`.