### PR TITLE
fix(frontend): clarify elimination section UX

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -425,13 +425,19 @@
       "youKilledCount": "You already killed {count} players."
     },
     "PlayerDashboardGameStartedKillCard": {
+      "ifYouAreEliminated": "If you are eliminated",
+      "myEliminationToken": "My elimination token",
       "presentQrCode": "If you get killed, present your QR code to the player, he will scan it to validate the kill. Do not try to scan it yourself, otherwise you'll (stupidly) get killed.",
       "onceDone": "Once the action is done, ask him his QR code and scan it to kill him.",
       "or": "OR",
       "youGetKilled": "You get killed?",
       "youNeedToKill": "You need to kill",
       "youNeedToMakeHimDo": "To kill him, you need to",
-      "yourCurrentMission": "Your current mission"
+      "yourCurrentMission": "Your current mission",
+      "miniGuideTitle": "How to eliminate your target",
+      "miniGuideStep1": "Accomplish your action on your target",
+      "miniGuideStep2": "Scan your target's QR code to eliminate them",
+      "showMyQrCode": "Show my QR code"
     },
     "PlayerDashboardGameUnStarted": {
       "gameWillStartSoon": "The game master will start the game soon.",

--- a/frontend/locales/fr.json
+++ b/frontend/locales/fr.json
@@ -428,13 +428,19 @@
       "youKilledCount_zero": "Tu n'as encore tué personne."
     },
     "PlayerDashboardGameStartedKillCard": {
+      "ifYouAreEliminated": "Si tu es éliminé",
+      "myEliminationToken": "Mon jeton d'élimination",
       "presentQrCode": "Si vous vous faites tuer, présentez votre code QR au joueur, il le scannera pour valider le meurtre. N'essayez pas de le scanner vous-même, sinon vous vous ferez (bêtement) tuer.",
       "onceDone": "Une fois l'action effectuée, demandez-lui son QR code et scannez-le pour l'éliminer.",
       "or": "OU",
       "youGetKilled": "Tu as été éliminé?",
       "youNeedToKill": "Tu dois tuer",
       "youNeedToMakeHimDo": "Pour l'éliminer, tu dois faire en sorte que",
-      "yourCurrentMission": "Ta mission en cours"
+      "yourCurrentMission": "Ta mission en cours",
+      "miniGuideTitle": "Comment éliminer ta cible",
+      "miniGuideStep1": "Accomplis ton action sur ta cible",
+      "miniGuideStep2": "Scanne le QR code de ta cible pour l'éliminer",
+      "showMyQrCode": "Afficher mon QR code"
     },
     "PlayerDashboardGameUnStarted": {
       "gameWillStartSoon": "L'administrateur de la partie va démarrer la partie dans quelques instants.",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@killer-game/frontend",
-  "version": "4.8.7",
+  "version": "4.8.8",
   "private": true,
   "engines": {
     "node": ">=24.0.0 <25.0.0"

--- a/frontend/src/components/pages/PlayerDashboardGameStarted.tsx
+++ b/frontend/src/components/pages/PlayerDashboardGameStarted.tsx
@@ -31,14 +31,33 @@ function HeroContentAlive(props: HeroContentAliveProps) {
   return (
     <>
       <h2 className={STYLES.h2}>
-        {t("PlayerDashboardGameStartedKillCard.youGetKilled")}
+        {t("PlayerDashboardGameStartedKillCard.miniGuideTitle")}
       </h2>
-      <p className="mb-2">
-        {t("PlayerDashboardGameStartedKillCard.presentQrCode")}
-      </p>
-      <div>
-        <PlayerKillQrCode game={props.game} lang={lang} player={props.player} />
-      </div>
+      <ol className="list-decimal list-inside mb-4 space-y-1">
+        <li>{t("PlayerDashboardGameStartedKillCard.miniGuideStep1")}</li>
+        <li>{t("PlayerDashboardGameStartedKillCard.miniGuideStep2")}</li>
+      </ol>
+
+      <details className="group bg-base-200 rounded-md p-2">
+        <summary className="cursor-pointer text-sm group-open:font-semibold group-open:text-accent list-none flex items-center gap-2">
+          <span className="flex-grow">
+            {t("PlayerDashboardGameStartedKillCard.myEliminationToken")}
+          </span>
+          <span className="group-open:hidden">▼</span>
+          <span className="hidden group-open:block">▲</span>
+        </summary>
+        <div className="mt-4">
+          <p className="mb-2 text-sm">
+            {t("PlayerDashboardGameStartedKillCard.ifYouAreEliminated")}:&nbsp;
+            {t("PlayerDashboardGameStartedKillCard.presentQrCode")}
+          </p>
+          <PlayerKillQrCode
+            game={props.game}
+            lang={lang}
+            player={props.player}
+          />
+        </div>
+      </details>
     </>
   );
 }


### PR DESCRIPTION
## Summary

Fixes #36.

The **"Tu as été éliminé?"** heading was the #1 point of confusion in the game: it appeared on the alive-player dashboard and implied the player had already been eliminated.

## Changes

- **Replaced** the always-visible "Tu as été éliminé?" heading with a clear **2-step mini-guide** titled *"Comment éliminer ta cible"*:
  1. Accomplis ton action sur ta cible
  2. Scanne le QR code de ta cible pour l'éliminer
- **Moved** the player's own elimination QR code into a **collapsible** *"Mon jeton d'élimination"* section (Option C from the issue), so it is only expanded when relevant instead of always being shown alongside the misleading heading.
- Added matching English copy.

## Rationale

Combines Option A (renaming) with Option C (collapsible section) from the issue, and adds the requested 2-step guide that distinguishes *showing your QR* vs *scanning your target's QR*.

## Tests

- `cd frontend && npm test` — all 49 tests pass (16 files).
- Bumped `frontend` patch version (4.8.7 → 4.8.8).