### PR TITLE
perf(frontend): prerender /en/help and other locale pages as static HTML

### DIFF
--- a/frontend/locales/en.json
+++ b/frontend/locales/en.json
@@ -486,7 +486,11 @@
       "or": "OR"
     },
     "HowDoesItWork": {
-      "title": "How does it work?"
+      "title": "How does it work?",
+      "descriptions": {
+        "1": "Each player gets a target and a wacky action to perform on them. Complete your mission to eliminate your target.",
+        "2": "When you eliminate a target, you inherit their target. The last player standing wins!"
+      }
     },
     "Pricing": {
       "description1": "I mean, really free! No credit, no account, no card required, no recurring fees, no ads: nothing!",

--- a/frontend/locales/fr.json
+++ b/frontend/locales/fr.json
@@ -487,7 +487,11 @@
       "or": "OU"
     },
     "HowDoesItWork": {
-      "title": "Comment ça marche ?"
+      "title": "Comment ça marche ?",
+      "descriptions": {
+        "1": "Chaque joueur reçoit une cible et une action farfelue à réaliser sur elle. Accomplissez votre mission pour éliminer votre cible.",
+        "2": "Quand vous éliminez une cible, vous héritez de sa cible. Le dernier joueur en lice remporte la partie !"
+      }
     },
     "Pricing": {
       "description1": "Je veux dire, vraiment gratuit ! Pas de crédit, pas de compte, pas de carte requise, pas de frais récurrents, pas de publicité : rien !",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@killer-game/frontend",
-  "version": "4.10.2",
+  "version": "4.10.3",
   "private": true,
   "engines": {
     "node": ">=24.0.0 <25.0.0"

--- a/frontend/src/__tests__/AiDocsPage.test.tsx
+++ b/frontend/src/__tests__/AiDocsPage.test.tsx
@@ -2,8 +2,11 @@ import { render, screen } from "@testing-library/react";
 import AiDocsPage from "@/app/[locale]/docs/ai/page";
 
 describe("AiDocsPage", () => {
-  it("renders the AI / MCP docs page without crashing", () => {
-    render(<AiDocsPage />);
+  it("renders the AI / MCP docs page without crashing", async () => {
+    const element = await AiDocsPage({
+      params: Promise.resolve({ locale: "en" }),
+    });
+    render(element);
 
     expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
   });

--- a/frontend/src/__tests__/GamesPage.test.jsx
+++ b/frontend/src/__tests__/GamesPage.test.jsx
@@ -1,11 +1,11 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import GamesPage from '@/app/[locale]/games/page';
 
 describe('GamesPage', () => {
-  it('renders without crashing', () => {
-    // This test just checks if the page can be rendered
-    // The actual components (GamesCreated and GamesJoined) are tested separately
-    expect(() => render(<GamesPage />)).not.toThrow();
+  it('renders without crashing', async () => {
+    const element = await GamesPage({
+      params: Promise.resolve({ locale: 'en' }),
+    });
+    expect(() => render(element)).not.toThrow();
   });
 });

--- a/frontend/src/__tests__/HomePage.test.tsx
+++ b/frontend/src/__tests__/HomePage.test.tsx
@@ -1,17 +1,21 @@
-import React from "react";
 import { render, screen } from "@testing-library/react";
 import HomePage from "@/app/[locale]/page";
 
 describe("HomePage", () => {
-  it("renders the homepage without crashing", () => {
-    render(<HomePage />);
+  it("renders the homepage without crashing", async () => {
+    const element = await HomePage({
+      params: Promise.resolve({ locale: "en" }),
+    });
+    render(element);
 
-    // Check if the main sections are rendered by checking for structural elements
     expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
   });
 
-  it("renders the tutorial example headings", () => {
-    render(<HomePage />);
+  it("renders the tutorial example headings", async () => {
+    const element = await HomePage({
+      params: Promise.resolve({ locale: "en" }),
+    });
+    render(element);
     expect(screen.getByRole("heading", { name: "step1.title" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "step2.title" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "step3.title" })).toBeInTheDocument();

--- a/frontend/src/app/[locale]/actions/page.tsx
+++ b/frontend/src/app/[locale]/actions/page.tsx
@@ -4,10 +4,21 @@ import GameCreateForm from "@/components/pages/GameCreateForm";
 import { STYLES } from "@/constants/styles";
 import { useDefaultActions } from "@/hooks/use-default-actions";
 import { useTranslations } from "next-intl";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import type { Metadata } from "next";
 
-export default function Page() {
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return <ActionsView />;
+}
+
+function ActionsView() {
   const t = useTranslations("actions");
   const tHome = useTranslations("homepage");
 

--- a/frontend/src/app/[locale]/docs/ai/page.tsx
+++ b/frontend/src/app/[locale]/docs/ai/page.tsx
@@ -1,6 +1,6 @@
 import { STYLES } from "@/constants/styles";
 import { useTranslations } from "next-intl";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import Link from "next/link";
 import { ReactNode } from "react";
 
@@ -77,7 +77,18 @@ function ToolItem({
   );
 }
 
-export default function AiDocsPage() {
+export default async function AiDocsPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return <AiDocsView />;
+}
+
+function AiDocsView() {
   const t = useTranslations("ai");
   const apiDocsUrl = process.env.NEXT_PUBLIC_API_URL
     ? `${process.env.NEXT_PUBLIC_API_URL}/docs`

--- a/frontend/src/app/[locale]/games/page.jsx
+++ b/frontend/src/app/[locale]/games/page.jsx
@@ -1,8 +1,13 @@
 import GamesCreated from "@/components/pages/GamesCreated";
 import GamesJoined from "@/components/pages/GamesJoined";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 
-export default function GamesPages() {
+export default async function GamesPages({
+  params,
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
   return (
     <>
       <GamesCreated />

--- a/frontend/src/app/[locale]/help/page.tsx
+++ b/frontend/src/app/[locale]/help/page.tsx
@@ -2,9 +2,20 @@ import FaqForPlayer from "@/components/organisms/FaqForPlayer";
 import GameTutorialExample from "@/components/organisms/GameTutorialExample";
 import { STYLES } from "@/constants/styles";
 import { useTranslations } from "next-intl";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 
-export default function HelpPage() {
+export default async function HelpPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return <HelpView />;
+}
+
+function HelpView() {
   const t = useTranslations("help");
 
   return (

--- a/frontend/src/app/[locale]/layout.tsx
+++ b/frontend/src/app/[locale]/layout.tsx
@@ -9,6 +9,10 @@ import "@/global.css";
 import { routing } from "@/i18n/routing";
 import { ReactNode } from 'react';
 
+export function generateStaticParams() {
+  return routing.locales.map((locale) => ({ locale }));
+}
+
 export default async function RootLayout({ children, params }: { children: ReactNode; params: Promise<{ locale: string }> }) {
   const { locale } = await params;
 

--- a/frontend/src/app/[locale]/page.tsx
+++ b/frontend/src/app/[locale]/page.tsx
@@ -6,7 +6,7 @@ import GameTutorialExample from "@/components/organisms/GameTutorialExample";
 import Testimonials from "@/components/organisms/Testimonials";
 import { STYLES } from "@/constants/styles";
 import { useLocale, useTranslations } from "next-intl";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import Link from "next/link";
 
 function HomeHeroCardContent() {
@@ -113,7 +113,18 @@ function Roadmap() {
   );
 }
 
-export default function Page() {
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  return <HomeView />;
+}
+
+function HomeView() {
   const t = useTranslations("common");
   const tHome = useTranslations("homepage");
   const tB2b = useTranslations("b2b");

--- a/frontend/src/app/[locale]/team-building/page.tsx
+++ b/frontend/src/app/[locale]/team-building/page.tsx
@@ -2,7 +2,7 @@ import B2BLeadForm from "@/components/organisms/B2BLeadForm";
 import Testimonials from "@/components/organisms/Testimonials";
 import { STYLES } from "@/constants/styles";
 import { useTranslations } from "next-intl";
-import { getTranslations } from "next-intl/server";
+import { getTranslations, setRequestLocale } from "next-intl/server";
 import type { Metadata } from "next";
 
 const BENEFIT_KEYS = ["noLogistics", "lastMinute", "customizable", "realTime"] as const;
@@ -15,7 +15,7 @@ export default async function TeamBuildingPage({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  void locale;
+  setRequestLocale(locale);
 
   return <TeamBuildingView />;
 }

--- a/frontend/vitest.setup.jsx
+++ b/frontend/vitest.setup.jsx
@@ -32,6 +32,7 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("next-intl/server", () => ({
   getTranslations: vi.fn(async () => createMockTranslator()),
+  setRequestLocale: vi.fn(),
 }));
 
 vi.mock("@/context/Toast", () => ({


### PR DESCRIPTION
## Problem

Closes #47.

The `/en/help` page consumed **1.6 GiB** of bandwidth for only **3,074 visitors** (~550 Ko/visitor), making it the most expensive page per visitor on the site.

## Root cause

With `next-intl` v4 and the App Router `[locale]` segment, pages are server-rendered on demand (`ƒ` dynamic) unless:

1. `generateStaticParams` is exported from the `[locale]` layout, **and**
2. `setRequestLocale(locale)` is called in every page that should be static.

Neither was the case here, so every visit to `/en/help` (and `/en`, `/en/actions`, `/en/games`, `/en/team-building`, `/en/docs/ai`) triggered a fresh SSR at the origin, returning a large HTML + RSC payload that could not be cached at the edge.

## Fix

- Add `generateStaticParams` to `[locale]/layout.tsx` returning the configured locales (`en`, `fr`).
- Convert each static locale page to an async server component that calls `setRequestLocale(locale)` before rendering its view:
  - `/en/help` (the page from the issue)
  - `/en` (homepage)
  - `/en/actions`
  - `/en/games`
  - `/en/team-building`
  - `/en/docs/ai`
- Pages that must remain dynamic (`force-dynamic` game/player pages) are untouched.
- Add the missing `homepage.HowDoesItWork.descriptions.{1,2}` translation keys (referenced by the actions page) that were previously hidden because the page was never prerendered at build. Surfaced as a build error once prerendering kicked in.
- Update the vitest setup mock to expose `setRequestLocale`, and adjust the `HomePage`, `AiDocsPage` and `GamesPage` tests to await the now-async page components (same pattern already used by `TeamBuildingPage.test.tsx`).

## Result

`next build` output before:

```
├ ƒ /[locale]
├ ƒ /[locale]/actions
├ ƒ /[locale]/docs/ai
├ ƒ /[locale]/games
├ ƒ /[locale]/help
├ ƒ /[locale]/team-building
```

`next build` output after:

```
├ ● /[locale]               /en            /fr
├ ● /[locale]/actions       /en/actions    /fr/actions
├ ● /[locale]/docs/ai       /en/docs/ai    /fr/docs/ai
├ ● /[locale]/games         /en/games      /fr/games
├ ● /[locale]/help          /en/help       /fr/help
├ ● /[locale]/team-building /en/team-building  /fr/team-building
```

All affected pages are now `● (SSG)` — prerendered as static HTML at build time and served as cacheable static assets. This eliminates the per-visit SSR cost and lets the pages be served (and cached) at the edge, which should dramatically reduce the ~550 Ko/visitor bandwidth reported in the issue.

## Verification

- `cd frontend && npx next build` — clean, no errors, all locale pages prerendered for `en` + `fr`.
- `cd frontend && npm test` — 64/64 tests pass.
- `cd api && npm test` — 109/109 pass (2 skipped).